### PR TITLE
make colors change when joining

### DIFF
--- a/scenes/game_object/player/player.gd
+++ b/scenes/game_object/player/player.gd
@@ -4,13 +4,23 @@ const MAX_SPEED = 300.0
 const ACCELERATION_SMOOTHING = 25
 
 @onready var barrel_tip: Marker2D = $Barrel
+@onready var tank_body: Sprite2D = $TankBody/Sprite2D
+@onready var barrel_color: Sprite2D = $Barrel/Sprite2D
 
 @onready var diagonal_movement: Array = [Vector2(-1, -1), Vector2(1, 1), Vector2(1, -1), Vector2(-1, 1)]
 @onready var previous_movement: Vector2 = Vector2.ZERO
 
 func _ready():
-	if $MultiplayerSynchronizer.get_multiplayer_authority() == multiplayer.get_unique_id():
+	var player_id = multiplayer.get_unique_id()
+	if $MultiplayerSynchronizer.get_multiplayer_authority() == player_id:
 		$Camera2D.make_current()
+		
+		var tank_color = GameManager.players[player_id].color
+		tank_body.texture = load(GameManager.color_dict[tank_color]["Body"])
+		tank_body.scale = Vector2(0.5, 0.5)
+		barrel_color.texture = load(GameManager.color_dict[tank_color]["Barrel"])
+		barrel_color.scale = Vector2(0.5, 0.5)
+
 
 func _process(delta):
 	if $MultiplayerSynchronizer.get_multiplayer_authority() != multiplayer.get_unique_id():

--- a/scenes/game_object/player/player.tscn
+++ b/scenes/game_object/player/player.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" path="res://scenes/game_object/player/player.gd" id="1_hkal2"]
 [ext_resource type="PackedScene" uid="uid://73lr8fqud4" path="res://scenes/component/health_component.tscn" id="2_gt4m0"]
 [ext_resource type="PackedScene" uid="uid://drybknwrows3o" path="res://scenes/game_object/player/tank_body.tscn" id="3_1e010"]
-[ext_resource type="Texture2D" uid="uid://8ip3d3virahl" path="res://scenes/game_object/player/tankGreen_barrel3_outline.png" id="3_vvwhs"]
+[ext_resource type="Texture2D" uid="uid://migc5rqexehm" path="res://scenes/game_object/player/tankGreen_barrel3_outline.png" id="3_vvwhs"]
 [ext_resource type="Script" path="res://scenes/game_object/player/Barrel.gd" id="4_yiyg3"]
 [ext_resource type="PackedScene" uid="uid://dp7s6opobih82" path="res://scenes/component/hurtbox_component.tscn" id="5_fvhfs"]
 

--- a/scenes/lobby.tscn
+++ b/scenes/lobby.tscn
@@ -125,7 +125,7 @@ popup/item_1/text = "Red"
 popup/item_1/id = 1
 popup/item_2/text = "Green"
 popup/item_2/id = 2
-popup/item_3/text = "Camo"
+popup/item_3/text = "Pink"
 popup/item_3/id = 3
 
 [node name="MultiplayerSynchronizer" type="MultiplayerSynchronizer" parent="."]

--- a/scenes/manager/game_manager.gd
+++ b/scenes/manager/game_manager.gd
@@ -7,3 +7,14 @@ var abilities = {
 	1: "res://scenes/ability/rapid_fire_ability/rapid_fire_ammo.tscn",
 	2: "spread",
 }
+
+var color_dict = {
+	"Blue": {"Barrel": "res://assets/sprites/Tanks/barrelBlue_outline.png",
+			 "Body": "res://assets/sprites/Tanks/tankBlue_outline.png"},
+	"Green": {"Barrel": "res://assets/sprites/Tanks/barrelGreen_outline.png",
+			  "Body": "res://assets/sprites/Tanks/tankGreen_outline.png"},
+	"Red": {"Barrel": "res://assets/sprites/Tanks/barrelRed_outline.png",
+			 "Body": "res://assets/sprites/Tanks/tankRed_outline.png"},
+	"Pink": {"Barrel": "res://assets/sprites/Tanks/barrelPink_outline.png",
+			 "Body": "res://assets/sprites/Tanks/tankPink_outline.png"},
+}


### PR DESCRIPTION
This update makes it so the tank changes color

BUG: have an issue where the texture doens't sync to the opposite player though. YOU see the different color, but your opponent is the default. Need to figure that out.

I also took out camo and substituted pink since we have a sprite for that. we can add all the others and even make a camo if we want to :).

These reference the tank barrels and bodies that Cody found and imported into the /assets folder