### PR TITLE
Fix issue resolving player when killed by falling box

### DIFF
--- a/scenes/component/environmental_component.gd
+++ b/scenes/component/environmental_component.gd
@@ -1,9 +1,10 @@
 extends Node2D
 class_name EnvironmentalComponent
 
-@onready var projectile_owner = 10101010
+@onready var projectile_owner = self
 @onready var animation_player : AnimationPlayer = $AnimationPlayer
 @export var damage = 10
+
 
 @rpc("any_peer", "call_local")
 func dead(id):

--- a/scenes/component/hurtbox_component.gd
+++ b/scenes/component/hurtbox_component.gd
@@ -22,8 +22,14 @@ func on_area_entered(other_area: Area2D):
 	
 	var hitbox_component = other_area as HitboxComponent
 	var player_hit = owner.name.to_int()
-	var player_hit_by = hitbox_component.get_parent().projectile_owner.name.to_int()
+	var player_hit_by = null
+	# this feels really dumb but for some reason the parent of the crates is resolving to "World"
+	if hitbox_component.get_parent().projectile_owner.name == "World":
+		player_hit_by = GameManager.ENVIRONMENT
+	else:
+		player_hit_by = hitbox_component.get_parent().projectile_owner.name.to_int()
 	
+	print(player_hit_by)
 	# this here will get called in all peers
 	health_component.damage.rpc(player_hit, player_hit_by, hitbox_component.get_parent().damage)
 	if !hitbox_component.hitbox_type == "Laser":

--- a/scenes/game_object/collectible/collectible_spawn.tscn
+++ b/scenes/game_object/collectible/collectible_spawn.tscn
@@ -1,9 +1,9 @@
 [gd_scene load_steps=9 format=3 uid="uid://dk6yy6rldr2s1"]
 
-[ext_resource type="Texture2D" uid="uid://cuhbswnm6qgn" path="res://assets/sprites/Collectibles/crateWood.png" id="1_017e1"]
+[ext_resource type="Texture2D" uid="uid://ih8cb8lgmbix" path="res://assets/sprites/Collectibles/crateWood.png" id="1_017e1"]
 [ext_resource type="Script" path="res://scenes/component/environmental_component.gd" id="1_c6unr"]
 [ext_resource type="Script" path="res://scenes/component/hitbox_component.gd" id="2_upva3"]
-[ext_resource type="Texture2D" uid="uid://catej61m76sbs" path="res://assets/sprites/Effects/Explosion2/explosionSmoke5.png" id="3_itkbg"]
+[ext_resource type="Texture2D" uid="uid://cygpqknfr176m" path="res://assets/sprites/Effects/Explosion2/explosionSmoke5.png" id="3_itkbg"]
 
 [sub_resource type="Animation" id="Animation_44epw"]
 length = 0.001
@@ -443,7 +443,7 @@ _data = {
 [sub_resource type="CircleShape2D" id="CircleShape2D_ea6hw"]
 radius = 68.1836
 
-[node name="10101010" type="Node2D"]
+[node name="10101010" type="Node2D" groups=["crate_drop"]]
 script = ExtResource("1_c6unr")
 damage = 50
 


### PR DESCRIPTION
Have to set the environmnet as the player_hit_by manually. It's resolving to "World" instead of the actual owner of the hitbox but I'm not sure why